### PR TITLE
flexible bip derivation in deriveaccount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,9 @@ fromSeed.prototype.getRootPublicKey = function () {
   return masterPub
 }
 
-fromSeed.prototype.deriveAccount = function (index) {
-  let keypath = "m/84'/" + this.slip44 + "'/" + index + "'"
+fromSeed.prototype.deriveAccount = function (index, bipNum) {
+  let bip = bipNum || '84'
+  let keypath = "m/" + bip + "'/" + this.slip44 + "'/" + index + "'"
     , account = bjs.bip32.fromSeed(this.seed, this.network).derivePath(keypath).toBase58()
     , masterPrv = this.isTestnet ?
                     vprv(account, this.pubTypes.testnet.vprv) :


### PR DESCRIPTION
Since pubTypes are specified on fromSeed, this already allows people to use X/Y/V/Z pub types with bip84 library making it agnostic of which type of derivation is happening. The only hardcoded place was deriveAccount and so let the user specifiy which type of bip derivation is required (default to 84). This will allow the library to support any of the BIP's working with xpub types.